### PR TITLE
Support raw hex data decode for Aqara S2 lock

### DIFF
--- a/lib/foundation.js
+++ b/lib/foundation.js
@@ -624,11 +624,15 @@ ru.clause('uint64', function (name) {
 ru.clause('strPreLenUint8', function (name) {
     parsedBufLen += 1;
     this.uint8('len').tap(function () {
-        var attrId = this.vars['attrId'];
-        var deviceId = zclId.device(260, 10).key;
+        const attrId = this.vars['attrId'];
+        const dataLen = this.vars['len'];
         // special xiaomi struct-string
-        if (attrId === 65281&&deviceId!=='doorLock') {
-            ru['xiaoMiStruct'](name)(this);
+        if (attrId === 65281&&dataLen!==16&&dataLen!==44) {
+          ru['xiaoMiStruct'](name)(this);
+        }
+        // special xiaomi struct-string for lock and curtain whitelist '65328' for lumi.lock.v1
+        else if ((dataLen===16||dataLen===44)&&attrId!=='65328') {
+          ru['xiaoMiStructLock'](name)(this);
         } else {
             parsedBufLen += this.vars.len;
             this.string(name, this.vars.len);
@@ -673,6 +677,14 @@ ru.clause('xiaoMiStruct', function (name) {
             this.vars.attrData = res;
         });
     });
+});
+
+ru.clause('xiaoMiStructLock', function (name) {
+  const len = parseInt(this.vars['len']);
+  this.buffer(name, len).tap(function () {
+    this.vars.attrData = buf2Str(this.vars[name]);
+    parsedBufLen += len;
+  });
 });
 
 ru.clause('strPreLenUint16', function (name) {


### PR DESCRIPTION
@Koenkk I improve https://github.com/Koenkk/zcl-packet/pull/5 and support raw hex string decode for S2 lock.

Also fix additional bug with aqara curtain and S2 lock, they produce more data could not decode and make it crash, you can see comment here https://github.com/Koenkk/zigbee2mqtt/issues/349#issuecomment-422002132