### PR TITLE
ADD moveColorTemp and stepColorTemp

### DIFF
--- a/lib/defs/zcl_meta.json
+++ b/lib/defs/zcl_meta.json
@@ -1200,6 +1200,19 @@
                     {"time":"uint16"},
                     {"starthue":"uint16"}
                 ],
+                "dir":0},
+            "moveColorTemp":{
+                "params":[
+                    {"ratex":"int16"},
+                    {"ratey":"int16"}
+                ],
+                "dir":0},
+            "stepColorTemp":{
+                "params":[
+                    {"stepx":"int16"},
+                    {"stepy":"int16"},
+                    {"transtime":"uint16"}
+                ],
                 "dir":0}
         },
         "ssIasZone": {


### PR DESCRIPTION
This is required for Osram Switch 4x EU-LIGHTIFY Implementation
Work for https://github.com/Koenkk/zigbee2mqtt/issues/159