### PR TITLE
Add entry for Osram proprietary cluster.

### DIFF
--- a/lib/defs/zcl_meta.json
+++ b/lib/defs/zcl_meta.json
@@ -1577,6 +1577,16 @@
                 "dir":0
             }               
         },
+        "manuSpecificOsram": {
+            "resetStartupParams": {
+                "params":[],
+                "dir":0
+            },
+            "saveStartupParams": {
+                "params":[],
+                "dir":0
+            }
+        },
         "manuSpecificPhilips": {
             "hueNotification":{
                 "params":[


### PR DESCRIPTION
This will allow lights to remember color/brightness/temp if power is
reset.