### PR TITLE
Fix crash with Aqara S2 lock

### DIFF
--- a/lib/foundation.js
+++ b/lib/foundation.js
@@ -625,8 +625,9 @@ ru.clause('strPreLenUint8', function (name) {
     parsedBufLen += 1;
     this.uint8('len').tap(function () {
         var attrId = this.vars['attrId'];
-        // special xiaomi struct-string
-        if (attrId === 65281) {
+        var deviceId = zclId.device(260, 10).key;
+        // special xiaomi struct-string, except xiaomi doorlock because it will crash
+        if (attrId === 65281&&deviceId!=='doorLock') {
             ru['xiaoMiStruct'](name)(this);
         } else {
             parsedBufLen += this.vars.len;


### PR DESCRIPTION
Fix issue: https://github.com/Koenkk/zigbee2mqtt/issues/349#issuecomment-422002132
This code need for the pull https://github.com/Koenkk/zigbee-shepherd-converters/pull/497
@Koenkk I make less change to zcl-packet, i also test it not affect exist device support in zigbee-shepherd-converters, it only crash with Aqara S2 doorlock and struct-string data of Xiaomi,  atribute id: **65281** so i whitelist **only Xiaomi lock** from this code.